### PR TITLE
Add an ambient dependency entry

### DIFF
--- a/ambient/node.json
+++ b/ambient/node.json
@@ -1,0 +1,5 @@
+{
+  "version": {
+    "0.12.0": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#8cf8164641be73e8f1e652c2a5b967c7210b6729"
+  }
+}

--- a/test.js
+++ b/test.js
@@ -47,7 +47,11 @@ glob('{ambient,bower,common,github,npm}/**/*.json', function (err, files) {
         Object.keys(data.version).forEach(function (version) {
           arrify(data.version[version]).forEach(function (location) {
             typingsBatch.push(function (done) {
-              typings.installDependency(location, { cwd: __dirname, name: 'test' })
+              typings.installDependency(location, {
+                cwd: __dirname,
+                name: 'test',
+                ambient: /^ambient/.test(file)
+              })
                 .then(function () {
                   return done()
                 }, done)


### PR DESCRIPTION
First ambient entry with tests passing, using `node.d.ts` from DefinitelyTyped.