### PR TITLE
uuid

### DIFF
--- a/npm/uuid.json
+++ b/npm/uuid.json
@@ -1,0 +1,6 @@
+{
+	"versions": {
+		"1.4.0": "github:rapropos/typed-node-uuid#75540df1d026d5c09db1a6b8feba4edf071574d1"
+	}
+}
+

--- a/npm/uuid.json
+++ b/npm/uuid.json
@@ -1,6 +1,6 @@
 {
 	"versions": {
-		"1.4.0": "github:rapropos/typed-node-uuid#75540df1d026d5c09db1a6b8feba4edf071574d1"
+		"1.4.0": "github:rapropos/typed-node-uuid#a2ad36f2802416729eaad89559d76e0b03ba673c"
 	}
 }
 


### PR DESCRIPTION
Adds typings for [node-uuid](https://github.com/broofa/node-uuid) hosted at [typed-node-uuid](https://github.com/rapropos/typed-node-uuid) under the name "uuid". The project itself is at 1.4.7, but from my understanding of your contribution guide, I set the supported version to 1.4.0. Let me know if this is a misunderstanding.