### PR TITLE
Added mongoose-timestamp

### DIFF
--- a/npm/mongoose-timestamp.json
+++ b/npm/mongoose-timestamp.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "0.5.0": "github:Fankserver/npm-mongoose-timestamp#67e521f1a25a2a21f25f7b74a7227ef36e0a8a7c"
+  }
+}


### PR DESCRIPTION
mongoose-timestamp require "mongoose" typings which doen't exist currently is this bad?