### PR TITLE
Added webpack

### DIFF
--- a/npm/webpack.json
+++ b/npm/webpack.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "1.12.9": "github:tkqubo/typed-webpack#49876a3de79056dd978ea8a68f0cf17d7332826f"
+    "1.12.9": "github:tkqubo/typed-webpack#642ef998dda5b1da61206122ad3a302b5845542a"
   }
 }

--- a/npm/webpack.json
+++ b/npm/webpack.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "1.12.9": "github:tkqubo/typed-webpack#642ef998dda5b1da61206122ad3a302b5845542a"
+    "1.12.9": "github:tkqubo/typed-webpack#10d2cc44a01602b87f8e999eec90192e7e6b3edc"
   }
 }

--- a/npm/webpack.json
+++ b/npm/webpack.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.12.9": "github:tkqubo/typed-webpack#49876a3de79056dd978ea8a68f0cf17d7332826f"
+  }
+}


### PR DESCRIPTION
This webpack type definition https://github.com/tkqubo/typed-webpack is almost simply copy-and-pasted from my original definitions committed to DefenitelyTyped repo.  Now I want to maintain this definition within typings ecosystem.  But I'm still not sure `npm/webpack.json` is the right place.  Anyway I'd appreciate if maintainer would check my PR :bow: