### PR TITLE
added reference to zoomcharts.d.ts

### DIFF
--- a/global/zoomcharts.json
+++ b/global/zoomcharts.json
@@ -1,0 +1,8 @@
+{
+  "versions": {
+    "1.9.0": "https://cdn.zoomcharts-cloud.com/1/9/latest/zoomcharts.d.ts",
+    "1.10.0": "https://cdn.zoomcharts-cloud.com/1/10/latest/zoomcharts.d.ts",
+    "1.11.0": "https://cdn.zoomcharts-cloud.com/1/11/latest/zoomcharts.d.ts",
+    "1.12.0": "https://cdn.zoomcharts-cloud.com/1/latest/zoomcharts.d.ts"
+  }
+}


### PR DESCRIPTION
The readme states that the typings have to be pushed to github repository. Is this mandatory? We already publish the .d.ts file with every release to our CDN that could be linked directly.

Would a reference like in this PR this be allowed in the registry?

Also I would like to better understand the value of specifying URLs to different versions. We have a definitions file attached to each version of the library - should I add those explicitly, like "1.11.0", "1.11.1", etc.? In the PR the last entry actually points to the CDN link that redirects to the most latest - which isn't exactly great considering that after few months the definition file might not match the 1.12 version anymore...