### PR TITLE
Fix empty module export.

### DIFF
--- a/npm/chai.json
+++ b/npm/chai.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "3.4.0": "github:typed-typings/npm-chai#450bf667f66ae45b23e72bd836d2b44835413df0"
+    "3.4.0": "github:typed-typings/npm-chai#01a92b8efc0cfa0ac894d695abd06b8b11e3b75b"
   }
 }


### PR DESCRIPTION
@blakeembrey, when I run `ts-node test/test.ts`, I got this error:
```sh
⨯ Unable to compile TypeScript

bundle.d.ts (460,5): Duplicate identifier 'should'. (2300)
lib/Chai.d.ts (29,5): Duplicate identifier 'should'. (2300)
```

The typings seems to be generated correctly (I tried it with `typings i file:typings.sjon`).

Seems like ts-node will compile based on `tsconfig.json`, which has reference to `index.d.ts` (thus loading `lib/Chai.d.ts`), and then run `test/test.ts` (thus loading `bundle.d.ts`).

Also, the seems to be an issue on the global augmentation. If two modules both augment global with the same name (`Object.should` in this case), the compilation fails?