### PR TITLE
fix for jasmine-node-promise-matchers

### DIFF
--- a/npm/jasmine-node-promise-matchers.json
+++ b/npm/jasmine-node-promise-matchers.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "0.0.3": "github:adamball/npm-jasmine-node-promise-matchers#56c07a89cf9864bc22501449a6d05af2b2ce4e1e"
+    "0.0.3": "github:adamball/typed-jasmine-node-promise-matchers#139a84fa30e3edfa40197a16a50ec5c029991a07"
   }
 }


### PR DESCRIPTION
Typings URL: https://github.com/adamball/typed-jasmine-node-promise-matchers
Source URL: https://github.com/agirorn/jasmine-node-promise-matchers

previous type definition was causing compile time errors, this PR contains the fix for that.