### PR TITLE
Updated mongoose timestamp

### DIFF
--- a/npm/mongoose-timestamp.json
+++ b/npm/mongoose-timestamp.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "0.5.0": "github:Fankserver/npm-mongoose-timestamp#67e521f1a25a2a21f25f7b74a7227ef36e0a8a7c"
+    "0.5.0": "github:Fankserver/npm-mongoose-timestamp#46367c3e46232e7711e855b7514a39f8b6cdff47"
   }
 }


### PR DESCRIPTION
I updated the code to use `import` instead of `require`
before the only way to import it:
```javascript
const timestamp = require("mongoose-timestamp");
```
and now import is also possible
```typescript
import * as timestamp from "mongoose-timestamp";
```

Typings URL: https://github.com/Fankserver/npm-mongoose-timestamp
Source URL: https://github.com/drudge/mongoose-timestamp

Was the way i changed the code right?
Is there a other way to use import?

