### PR TITLE
Add typings for mailchimp-api module

### DIFF
--- a/npm/mailchimp-api.json
+++ b/npm/mailchimp-api.json
@@ -1,0 +1,5 @@
+{ 
+    "versions": { 
+        "2.0.0": "github:typed-contrib/mailchimp-api#4f95e1ce4582710911977675a2d235315bd612e0" 
+    } 
+} 


### PR DESCRIPTION
Typings URL: [https://github.com/typed-contrib/mailchimp-api]
Source URL: [https://bitbucket.org/mailchimp/mailchimp-api-node/]