### PR TITLE
Add typings for knockout.mapping global

### DIFF
--- a/global/knockout.mapping.json
+++ b/global/knockout.mapping.json
@@ -1,0 +1,5 @@
+{ 
+    "versions": { 
+        "2.0.0": "github:typed-contrib/knockout.mapping/global/typings.json#ea8c41fd6736738b8987f66187cb0b4851e0d15c" 
+    } 
+} 


### PR DESCRIPTION
Typings URL: [https://github.com/typed-contrib/knockout.mapping]
 Source URL: [https://github.com/SteveSanderson/knockout.mapping]
 Documentation URL : [http://knockoutjs.com/documentation/plugins-mapping.html]