### PR TITLE
Add typings for require.js npm module

### DIFF
--- a/npm/requirejs.json
+++ b/npm/requirejs.json
@@ -1,0 +1,5 @@
+{ 
+    "versions": { 
+        "2.2.0": "github:typed-contrib/requirejs/node/typings.json#351aee1093083c1357f06b0fb5e9abb520537140" 
+    } 
+} 


### PR DESCRIPTION
Typings URL: [https://github.com/typed-contrib/requirejs/node]
Source URL: [https://github.com/requirejs/r.js]
Documentation URL: [http://requirejs.org/docs/node.html]