### PR TITLE
Add env-mocha

### DIFF
--- a/env/mocha.json
+++ b/env/mocha.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "2.2.5": "github:typed-typings/env-mocha#749e3d8a4f5a7f4ff817a12011f3531e5f4f2ce8"
+  }
+}


### PR DESCRIPTION
Typings URL: [E.g. http://github.com/typed-typings/env-mocha]
Source URL: [E.g. https://github.com/mochajs/mocha]

Is it correct that I skip the `main` field when specifying `files`?
```js
{
  "name": "mocha",
  "ambient": true,
  "files": [
    "lib/global.d.ts",
    "lib/mocha.d.ts"
  ],
  "homepage": "https://github.com/mochajs/mocha"
}
```

Fixes #81 