### PR TITLE
support for markdown-it

### DIFF
--- a/npm/markdown-it.json
+++ b/npm/markdown-it.json
@@ -1,6 +1,6 @@
 {
 	"versions": {
-		"4.0.0": "github:rapropos/typed-markdown-it#455e8241ab764385182fffa03dd06cd2080b2331"
+		"4.0.0": "github:rapropos/typed-markdown-it#71e0f4babb2878267f54503ed89ad05609df71f3"
 	}
 }
 

--- a/npm/markdown-it.json
+++ b/npm/markdown-it.json
@@ -1,0 +1,6 @@
+{
+	"versions": {
+		"4.0.0": "github:rapropos/typed-markdown-it#455e8241ab764385182fffa03dd06cd2080b2331"
+	}
+}
+


### PR DESCRIPTION
Typings URL: [https://github.com/rapropos/typed-markdown-it]
Source URL: [https://github.com/markdown-it/markdown-it]
