### PR TITLE
Add registry entry for google-web-signin

### DIFF
--- a/global/google-web-signin.json
+++ b/global/google-web-signin.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.0.0": "github:flawless2011/typings-google-web-signin#5dabf489e0d3e64506a141ce8876439dd15560e5"
+  }
+}


### PR DESCRIPTION
Typings definition for Google Web Sign-In library.  This is a migration from DefinitelyTyped so let me know if anything looks out of wack.

Typings URL: [https://github.com/flawless2011/typings-google-web-signin]
Source URL: [https://developers.google.com/identity/sign-in/web/reference#gapiauth2]

