### PR TITLE
added rxjs-symbol-typings

### DIFF
--- a/lib/rxjs-symbol-typings.json
+++ b/lib/rxjs-symbol-typings.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.0.0": "github:david-driscoll/rxjs-symbol-typings#b06ca4cc670b9e0f2ace68a339dce38648e10e6c"
+  }
+}


### PR DESCRIPTION
Filling in these fields will make it easier for us to review:

Typings URL: https://github.com/david-driscoll/rxjs-symbol-typings
Source URL: https://github.com/ReactiveX/rxjs/blob/master/spec/es5.d.ts

This is a small supplemental interface shim, to allow RxJS5 to target ES6 while still being compatible with TypeScript compilers that target `ES5`.  Only users that target ES5 will need to install this side by side with Rxjs5.
