### PR TITLE
Add csv-parse.json

### DIFF
--- a/npm/csv-parse.json
+++ b/npm/csv-parse.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "1.0.2": "github:nashika/typed-csv-parse#07d46ebaceab959b71a5b4ec15953f08beeb82b3"
+    "1.0.2": "github:nashika/typed-csv-parse#b300d8674f93cfd70a02e5c45354d980a7179a2e"
   }
 }

--- a/npm/csv-parse.json
+++ b/npm/csv-parse.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.0.2": "github:nashika/typed-csv-parse#07d46ebaceab959b71a5b4ec15953f08beeb82b3"
+  }
+}


### PR DESCRIPTION
Typings URL: [E.g. https://github.com/nashika/typed-csv-parse]
Source URL: [E.g. https://github.com/wdavidw/node-csv-parse]

I create node csv-parse definition.

This module is CSV text file reader module.
Module normally run in asynchronous.
and this module have sync version.

[Usage of sync version (js)]
```js
var parse = require('csv-parse/lib/sync');
var resultObject = parse(csvString);
```

But, i cant find how to create "slash included" module definition.

I create sync version definition in sync directory.
And add dependency to my app typings.json like this
```js
"dependencies": {
  "csv-parse": "github:nashika/typed-csv-parse#07d46ebaceab959b71a5b4ec15953f08beeb82b3",
  "csv-parse/lib/sync": "github:nashika/typed-csv-parse/sync#07d46ebaceab959b71a5b4ec15953f08beeb82b3"
}
```
My app ts compile was succeed.
But I cant find how to write it to "npm/csv-parse.json" file.

What should I do?

UPDATED by @unional: prettify code. :smile: