### PR TITLE
Update (global) knockout-postbox@0.5.2

### DIFF
--- a/global/knockout-postbox.json
+++ b/global/knockout-postbox.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "0.5.2": "github:jgoz/typed-knockout-postbox/global/typings.json#6ec4b32c63e8325d221fae80d2f253487d59ae3c"
+    "0.5.2": "github:jgoz/typed-knockout-postbox/global/typings.json#982661db75cd28ffbb1b3e86a9593f82adab5c5b"
   }
 }


### PR DESCRIPTION
Typings URL: https://github.com/jgoz/typed-knockout-postbox
Source URL: https://github.com/rniemeyer/knockout-postbox

Updated commit hash for `global` typings based on feedback in #299.