### PR TITLE
Add unambient immutable typings

### DIFF
--- a/npm/immutable.json
+++ b/npm/immutable.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "3.7.6": "github:alitaheri/immutable-unambient#c7987e0b221760db96efccdf37222d24ed87759e"
+    "3.7.6": "github:alitaheri/immutable-unambient#3e5ef14e1677e2db90770b8263be889b71c4d444"
   }
 }

--- a/npm/immutable.json
+++ b/npm/immutable.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "3.7.6": "github:alitaheri/immutable-unambient#c7987e0b221760db96efccdf37222d24ed87759e"
+  }
+}


### PR DESCRIPTION
As it rose in https://github.com/typings/typings/issues/428 and the fact that immutable js is not being very actively maintained, I decided to add the unambient types to the registry, thanks to how the typings were originally written it was very easy! just remove 5 lines of codes and vola :sunglasses: I also renamed `module` to `namespace` as it's being deprecated. I tested it with my projects and it's working perfectly. please have a look.

Typings URL: https://github.com/alitaheri/immutable-unambient
Source URL: https://github.com/facebook/immutable-js