### PR TITLE
Add typings for env-node

### DIFF
--- a/env/node.json
+++ b/env/node.json
@@ -1,0 +1,9 @@
+{
+  "versions": {
+    "0.8.0": "github:typed-typings/env-node/0.8#8feb3e2f7099efe714d44ef95562d4fba7a671c5",
+    "0.10.0": "github:typed-typings/env-node/0.10#8feb3e2f7099efe714d44ef95562d4fba7a671c5",
+    "0.11.0": "github:typed-typings/env-node/0.11#8feb3e2f7099efe714d44ef95562d4fba7a671c5",
+    "0.12.0": "github:typed-typings/env-node/0.12#8feb3e2f7099efe714d44ef95562d4fba7a671c5",
+    "4.0.0": "github:typed-typings/env-node/4#8feb3e2f7099efe714d44ef95562d4fba7a671c5"
+  }
+}


### PR DESCRIPTION
Typings URL: http://github.com/typed-typings/env-node
Source URL: https://nodejs.org/

Closes #251