### PR TITLE
Update blue-tape.json

### DIFF
--- a/npm/blue-tape.json
+++ b/npm/blue-tape.json
@@ -1,6 +1,5 @@
 {
   "versions": {
-    "0.1.0": "github:typed-typings/npm-blue-tape#3de9a90b45538efc80d9c87f4a51f99abb8e810b",
-    "0.2.0": "github:typed-typings/npm-blue-tape#9702bae77a610a625696fef90f9792ea7092e49e"
+    "0.1.0": "github:typed-typings/npm-blue-tape#3de9a90b45538efc80d9c87f4a51f99abb8e810b"
   }
 }


### PR DESCRIPTION
Temp revert to not releasing `0.2.0` to avoid bug introduced