### PR TITLE
Update npm/del

### DIFF
--- a/npm/del.json
+++ b/npm/del.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "2.2.0": "github:MrHen/typings-del#8617a6f468ed26568b27c7370ac030a23842eb3a"
+    "2.2.0": "github:MrHen/typings-del#6870e56e4bb674290c131ee634e22aea7e31c1cd"
   }
 }


### PR DESCRIPTION
Typings URL: https://github.com/MrHen/typings-del
Source URL: https://github.com/sindresorhus/del

Changes: [Last PR](https://github.com/typings/registry/pull/321) had an older commit. This attaches the Options interface appropriately.