### PR TITLE
Updated mongodb to new commit hash

### DIFF
--- a/npm/mongodb.json
+++ b/npm/mongodb.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "2.1.0": "github:Think7/typings-mongodb#3a50a13eeb9fbb63f8759200dcb2bf576ff33285"
+    "2.1.0": "github:Think7/typings-mongodb#e72e4c62896ceee80c8786f2e10b28da6c8c2481"
   }
 }


### PR DESCRIPTION
Added some cleanup to the type definition file and some deprecated methods to the collection interface.

Typings URL: [https://github.com/Think7/typings-mongodb]
Source URL: [http://mongodb.github.io/node-mongodb-native/2.1/api]


