### PR TITLE
Updated commit for rwlock and mongodb

### DIFF
--- a/npm/mongodb.json
+++ b/npm/mongodb.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "2.1.0": "github:Think7/typings-mongodb#3a50a13eeb9fbb63f8759200dcb2bf576ff33285"
+    "2.1.0": "github:Think7/typings-mongodb#e72e4c62896ceee80c8786f2e10b28da6c8c2481"
   }
 }

--- a/npm/mongodb.json
+++ b/npm/mongodb.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "2.1.0": "github:Think7/typings-mongodb#e72e4c62896ceee80c8786f2e10b28da6c8c2481"
+    "2.1.0": "github:Think7/typings-mongodb#1061602e147ad58973dfb78f5ce5424f673eb05f"
   }
 }

--- a/npm/rwlock.json
+++ b/npm/rwlock.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "5.0.0": "github:CaselIT/typings-rwlock#f3519a868b4a3a989e8376316b43b72b26d40e44"
+    "5.0.0": "github:CaselIT/typings-rwlock#40643e82365784176a7547412c17dd8863ed4a05"
   }
 }

--- a/npm/rwlock.json
+++ b/npm/rwlock.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "5.0.0": "github:CaselIT/typings-rwlock#26fc7428e4ac01271fe48bdd8f47ca50dc804d33"
+    "5.0.0": "github:CaselIT/typings-rwlock#98f6480d8f7b185d4e1afe099725ee6b81699806"
   }
 }

--- a/npm/rwlock.json
+++ b/npm/rwlock.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "5.0.0": "github:CaselIT/typings-rwlock#f3519a868b4a3a989e8376316b43b72b26d40e44"
+  }
+}

--- a/npm/rwlock.json
+++ b/npm/rwlock.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "5.0.0": "github:CaselIT/typings-rwlock#40643e82365784176a7547412c17dd8863ed4a05"
+    "5.0.0": "github:CaselIT/typings-rwlock#26fc7428e4ac01271fe48bdd8f47ca50dc804d33"
   }
 }


### PR DESCRIPTION
Updated hash to new version.
Typings URL: [https://github.com/CaselIT/typings-rwlock]
Source URL: [https://github.com/71104/rwlock]
Typings URL: [https://github.com/Think7/typings-mongodb]
Source URL: [http://mongodb.github.io/node-mongodb-native/2.1/api]

