### PR TITLE
Updated commit for mongodb

### DIFF
--- a/npm/mongodb.json
+++ b/npm/mongodb.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "2.1.0": "github:Think7/typings-mongodb#1061602e147ad58973dfb78f5ce5424f673eb05f"
+    "2.1.0": "github:Think7/typings-mongodb#7abdf73d9c363fcef21395d90a67aaf048943875"
   }
 }

--- a/npm/mongodb.json
+++ b/npm/mongodb.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "2.1.0": "github:Think7/typings-mongodb#7abdf73d9c363fcef21395d90a67aaf048943875"
+    "2.1.0": "github:Think7/typings-mongodb#d4269a9c672ab28a7865b38c8614673e8aecc8e5"
   }
 }


### PR DESCRIPTION
Typings URL: [https://github.com/Think7/typings-mongodb]
Source URL: [http://mongodb.github.io/node-mongodb-native/2.1/api]
Sorry to be back again so soon, but I missed a change yesterday.
Thanks!

