### PR TITLE
Add npm:facebook-chat-api

### DIFF
--- a/npm/facebook-chat-api.json
+++ b/npm/facebook-chat-api.json
@@ -1,0 +1,5 @@
+{
+    "versions": {
+        "1.1.0": "github:insa-frif/typed-facebook-chat-api#db2780ef99705af4d568230c16893f3ea52d372c"
+    }
+}


### PR DESCRIPTION
Typings for `npm:facebook-chat-api`

Typings URL: https://github.com/insa-frif/typed-facebook-chat-api
Source URL: https://github.com/Schmavery/facebook-chat-api


