### PR TITLE
Update bluebird.json

### DIFF
--- a/npm/bluebird.json
+++ b/npm/bluebird.json
@@ -1,6 +1,5 @@
 {
   "versions": {
-    "3.2.1": "github:typed-typings/npm-bluebird#524d5cc66654fe7c8dcbccf90faeaa70588853a0",
-    "3.3.4": "github:typed-typings/npm-bluebird#cfd8d3ac544649768a437b5f707fedbe4a60cd18"
+    "3.3.4": "github:typed-typings/npm-bluebird#92126fa3d066d07af9e93068e10a6800567c0551"
   }
 }


### PR DESCRIPTION
Added new version and deprecated old one due to a bug in the typings file.

Methods `.inspect` and `.settle` have been deprecated since version 2. Replaced with `.reflect`.