### PR TITLE
Add npm/js-sha256

### DIFF
--- a/npm/js-sha256.json
+++ b/npm/js-sha256.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "0.3.0": "github:demurgos/typed-js-sha256#ce991a5c69d819c4ee7a6de223b1233d2bf16fb7"
+  }
+}


### PR DESCRIPTION
Typings URL: https://github.com/Demurgos/typed-js-sha256
Source URL: https://github.com/emn178/js-sha256

I added a warning in the `README.md` because I had a doubt: this module both uses the Node's "function as a module" export and exports a `namespace` being strict-commonjs/ES6 standard-compliant.
When both are available, should I still expose the non-standard way ? With Typescript supporting ES6 modules from the beginning, it's does not complicate the import on the consumer side.

This way of exporting also has a few side-effects: the object is circular:
````typescript
import {sha256} from "js-sha256";
console.log(sha256.sha256 === sha256); // true
````
But this is not documented.
Also, the implementation uses an optional parameter but the documentation never mentions it: it's in fact an internal "flag". Should I define it as optional or do not expose this private signature ?