### PR TITLE
Update npm/facebook-chat-api

### DIFF
--- a/npm/facebook-chat-api.json
+++ b/npm/facebook-chat-api.json
@@ -1,5 +1,5 @@
 {
-    "versions": {
-        "1.1.0": "github:insa-frif/typed-facebook-chat-api#db2780ef99705af4d568230c16893f3ea52d372c"
-    }
+  "versions": {
+    "1.1.0": "github:insa-frif/typed-facebook-chat-api#1bfa716b7e263212d755af20fe21a648b72b609b"
+  }
 }


### PR DESCRIPTION
Typings URL: https://github.com/insa-frif/typed-facebook-chat-api
Source URL: https://github.com/Schmavery/facebook-chat-api

Changes:

 - `facebookChatApi.getUserInfo`

 - Normalize type for ID (when an argument is an ID, it is `number | string`, an ID in a result is always `string`)

- Errors are not native errors but `ErrorObject`s

- Use the method proposed in #347 to export the main function

- Lint and minor re-factoring



