### PR TITLE
Add npm/are-we-there-yet

### DIFF
--- a/npm/are-we-there-yet.json
+++ b/npm/are-we-there-yet.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.1.2": "github:demurgos/typed-are-we-there-yet#4241e0d0303833f08099643130af9a3f7d48f31c"
+  }
+}


### PR DESCRIPTION
Typings URL: https://github.com/Demurgos/typed-are-we-there-yet
Source URL: https://github.com/iarna/are-we-there-yet

A few notes about these typings:
 - I don't have a clue about how to expose events

 - The definitions use node's `stream` while the real module uses `readable-stream`. Both should be compatible but it has to be fixed once the definitions for `readable-stream` are available.

- I had an issue with the presence of one method (`finish()` on `TrackerStream`). I opened a ticket on their repo because I think there might be a difference between what is documented and what is implemented.
