### PR TITLE
Update npm/are-we-there-yet

### DIFF
--- a/npm/are-we-there-yet.json
+++ b/npm/are-we-there-yet.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "1.1.2": "github:demurgos/typed-are-we-there-yet#4241e0d0303833f08099643130af9a3f7d48f31c"
+    "1.1.2": "github:demurgos/typed-are-we-there-yet#2b89984c98b6fe3c3df276bd1739011f343ab7cf"
   }
 }


### PR DESCRIPTION
Typings URL: https://github.com/Demurgos/typed-are-we-there-yet
Source URL: https://github.com/iarna/are-we-there-yet

Adds support for events as explained by @blakeembrey in #364.

Related commit: https://github.com/Demurgos/typed-are-we-there-yet/commit/2b89984c98b6fe3c3df276bd1739011f343ab7cf

