### PR TITLE
Add meteor typings to the registry

### DIFF
--- a/env/meteor.json
+++ b/env/meteor.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.3.0": "github:barbatus/meteor-typings/meteor/1.3#83c6933d0ef07abfd4a2a85b5ec41bc3949f6d28"
+  }
+}


### PR DESCRIPTION
**Typings URL:** https://github.com/barbatus/meteor-typings

Add type definitions for Meteor 1.3. 
There was a PR to the DefinitelyTyped regarding this (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/9113) but I thought it's time to move definitions here.
I believe it will be maintained in barbatus/meteor-typings (or under another global repo in the future) from now on.
