### PR TITLE
Update `tough-cookie` typings

### DIFF
--- a/npm/tough-cookie.json
+++ b/npm/tough-cookie.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "2.2.0": "github:typed-typings/npm-tough-cookie#3e37dc2e6d448130d2fa4be1026e195ffda2b398"
+    "2.2.0": "github:typed-typings/npm-tough-cookie#235987754f775ce1374d2b551175cc1d356e3935"
   }
 }


### PR DESCRIPTION
**Typings URL:** https://github.com/typed-typings/npm-tough-cookie

**Change Summary (for existing typings):**

* Fixed the return type of `setCookieSync`

Thanks for contributing! This information helps us and the community stay in sync.

