### PR TITLE
Add npm/big-integer

### DIFF
--- a/npm/big-integer.json
+++ b/npm/big-integer.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.6.15": "github:Demurgos/typed-big-integer#48689e49d3de3c500a549361fd132a6ad8af0954"
+  }
+}


### PR DESCRIPTION
**Typings URL:** https://github.com/Demurgos/typed-big-integer

**Questions (for new typings):**

* [x] Does the README explain the purpose and a link to the typed source?
* [x] Do the typings follow the source structure?
* [x] Are they correctly external or ambient modules?

Notes:
 - `big-integer` defines "prestored" values as constants for numbers from -999 to 999. Currently I defined these constants by generating the whole sequence, I'm not sure if there is a smarter way to do it. (I'm not even sure if Typescript recognizes it correctly, it does not complain when the number is in the range, but it does not complain either when the number is outside of the range - and I don't get auto-completion with WebStorm).

- The operator `+` relying on `valueOf` does not work with Typescript yet. Related issue: https://github.com/Microsoft/TypeScript/issues/2361

