### PR TITLE
Golden Layout typings are now included in the source package

### DIFF
--- a/npm/golden-layout.json
+++ b/npm/golden-layout.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "1.5.0": "github:Genedata/typed-golden-layout#1d4ecae4388d28ee93f4372d5f09a47183e10bb5"
+    "1.5.0": "github:deepstreamIO/golden-layout#b86019272af8c08199d325ad32b8e3c06ffdd01c"
   }
 }

--- a/npm/golden-layout.json
+++ b/npm/golden-layout.json
@@ -1,5 +1,0 @@
-{
-  "versions": {
-    "1.5.0": "github:deepstreamIO/golden-layout#b86019272af8c08199d325ad32b8e3c06ffdd01c"
-  }
-}


### PR DESCRIPTION
The typings are now included in the original source package:

Typings URL: [https://github.com/deepstreamIO/golden-layout]
Source URL = Typings URL

I would therefore like to remove this entry from the registry--it's very new so, ideally, before people start using it!
