### PR TITLE
change enum declaration to type

### DIFF
--- a/npm/jsonld.json
+++ b/npm/jsonld.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "0.4.0": "github:tpluscode/jsonld-typings#6859a022544a3091988974f7a0e9c32c9773d603"
+    "0.4.0": "github:tpluscode/jsonld-typings#39e4819b05ab05c3e79d56c6bb64c48fab6c04a6"
   }
 }


### PR DESCRIPTION
**Typings URL:** https://github.com/tpluscode/jsonld-typings

**Change Summary (for existing typings):**

Invalid `enum` syntax broke `tsc`. I've changed it to a [string union type](https://basarat.gitbooks.io/typescript/content/docs/types/stringLiteralType.html)

