### PR TITLE
Update `arrify` with `void` signature

### DIFF
--- a/npm/arrify.json
+++ b/npm/arrify.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "1.0.0": "github:typed-typings/npm-arrify#32383d5fd3e6a8614abb6dba254a3aab07cd7424"
+    "1.0.0": "github:typed-typings/npm-arrify#df1f3102e97f6d0aadcd06da2c7c1eb069304f5b"
   }
 }


### PR DESCRIPTION
**Typings URL:** https://github.com/typed-typings/npm-arrify

**Change Summary (for existing typings):**

If anyone is looking at this, TypeScript 1.9 (`@next`) introduces `strictNullChecks`. Without `void` explicitly in the signature, potentially `undefined` values would be rejected.
