### PR TITLE
Add type definitions for i2c-bus

### DIFF
--- a/npm/i2c-bus.json
+++ b/npm/i2c-bus.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.0.0": "github:101100/typed-i2c-bus#3af7588bedbac004de1bd65b445381bf6268e7f4"
+  }
+}


### PR DESCRIPTION
**Typings URL:** https://github.com/101100/typed-i2c-bus

**Questions (for new typings):**

* [X] Does the README explain the purpose and a link to the typed source?
* [X] Do the typings follow the source structure?
* [X] Are they correctly external or ambient modules?