### PR TITLE
Add a base ES2015 env typings to unify modules depending on ES2015 features (Promise)

### DIFF
--- a/env/es2015-array.json
+++ b/env/es2015-array.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.0.0": "github:typed-contrib/es2015/array/typings.json#0.1.3"
+  }
+}

--- a/env/es2015-collections.json
+++ b/env/es2015-collections.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.0.0": "github:typed-contrib/es2015/collections/typings.json#0.1.3"
+  }
+}

--- a/env/es2015-math.json
+++ b/env/es2015-math.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.0.0": "github:typed-contrib/es2015/math/typings.json#0.1.3"
+  }
+}

--- a/env/es2015-number.json
+++ b/env/es2015-number.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.0.0": "github:typed-contrib/es2015/number/typings.json#0.1.3"
+  }
+}

--- a/env/es2015-object.json
+++ b/env/es2015-object.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.0.0": "github:typed-contrib/es2015/object/typings.json#0.1.3"
+  }
+}

--- a/env/es2015-promise.json
+++ b/env/es2015-promise.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.0.0": "github:typed-contrib/es2015/promise/typings.json#0.1.3"
+  }
+}

--- a/env/es2015-reflect.json
+++ b/env/es2015-reflect.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.0.0": "github:typed-contrib/es2015/reflect/typings.json#0.1.3"
+  }
+}

--- a/env/es2015-string.json
+++ b/env/es2015-string.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.0.0": "github:typed-contrib/es2015/string/typings.json#0.1.3"
+  }
+}

--- a/env/es2015-symbol.json
+++ b/env/es2015-symbol.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.0.0": "github:typed-contrib/es2015/symbol/typings.json#0.1.3"
+  }
+}

--- a/env/es2015.json
+++ b/env/es2015.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.0.0": "github:typed-contrib/es2015#0.1.3"
+  }
+}


### PR DESCRIPTION
**Typings URL:** https://github.com/typed-contrib/es2015
**Specification:** http://www.ecma-international.org/ecma-262/6.0/

**Questions (for new typings):**

* [x] Does the README explain the purpose and a link to the typed source?
* [x] Do the typings follow the source structure (e.g. `index.js` <-> `index.d.ts`)?
* [x] Are they correctly external or global modules?

I made this typings to unify modules dependencies. This avoid to:
* Avoid the use of different "polyfill" definitions in each modules (Promise, Map, Set, etc.).
* Allows users to use ES2015 features on their ES5 targetted projects or lib.
* Allows users to take only the features they need.

Do you think it's a good idea ?