### PR TITLE
Update google-web-signin to 1.1.0

### DIFF
--- a/global/google-web-signin.json
+++ b/global/google-web-signin.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "1.0.0": "github:flawless2011/typings-google-web-signin#5dabf489e0d3e64506a141ce8876439dd15560e5"
+    "1.1.0": "github:flawless2011/typings-google-web-signin#1c87c7fa159ad709655a80487f320bad82dc0889"
   }
 }


### PR DESCRIPTION
**Typings URL:** [https://github.com/flawless2011/typings-google-web-signin]

**Change Summary (for existing typings):**
* Added missing `GoogleUser` parameter in the `onsuccess` callback for `GoogleAuth.attachClickHandler()`
* Updated version to 1.1.0