### PR TITLE
Update Meteor typings 

### DIFF
--- a/env/meteor.json
+++ b/env/meteor.json
@@ -1,6 +1,5 @@
 {
   "versions": {
-    "1.3.0": "github:meteor-typings/meteor/1.3#64f0d62cb163049fd2c04c71ac1a8402b4ff6c9e",
     "1.2.0": "github:meteor-typings/meteor/1.2#64f0d62cb163049fd2c04c71ac1a8402b4ff6c9e"
   }
 }

--- a/env/meteor.json
+++ b/env/meteor.json
@@ -1,5 +1,6 @@
 {
   "versions": {
-    "1.3.0": "github:barbatus/meteor-typings/meteor/1.3#83c6933d0ef07abfd4a2a85b5ec41bc3949f6d28"
+    "1.3.0": "github:meteor-typings/meteor/1.3#64f0d62cb163049fd2c04c71ac1a8402b4ff6c9e",
+    "1.2.0": "github:meteor-typings/meteor/1.2#64f0d62cb163049fd2c04c71ac1a8402b4ff6c9e"
   }
 }

--- a/env/meteor.json
+++ b/env/meteor.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.3.0": "github:barbatus/meteor-typings/meteor/1.3#83c6933d0ef07abfd4a2a85b5ec41bc3949f6d28"
+  }
+}

--- a/env/meteor.json
+++ b/env/meteor.json
@@ -1,6 +1,6 @@
 {
   "versions": {
-    "1.2.0": "github:meteor-typings/meteor/1.2#76c8c548924072b63bf0c51f61555113d3e09383",
-    "1.3.0": "github:meteor-typings/meteor/1.3#76c8c548924072b63bf0c51f61555113d3e09383"
+    "1.2.0": "github:meteor-typings/meteor/1.2#f63c5e15a2b39a60a938851a657a51dcd9429b73",
+    "1.3.0": "github:meteor-typings/meteor/1.3#f63c5e15a2b39a60a938851a657a51dcd9429b73"
   }
 }

--- a/env/meteor.json
+++ b/env/meteor.json
@@ -1,6 +1,6 @@
 {
   "versions": {
-    "1.2.0": "github:meteor-typings/meteor/1.2#ab59b28167c5207feb93fbb6132ef8a6be98dbbb",
-    "1.3.0": "github:meteor-typings/meteor/1.3#ab59b28167c5207feb93fbb6132ef8a6be98dbbb"
+    "1.2.0": "github:meteor-typings/meteor/1.2#76c8c548924072b63bf0c51f61555113d3e09383",
+    "1.3.0": "github:meteor-typings/meteor/1.3#76c8c548924072b63bf0c51f61555113d3e09383"
   }
 }

--- a/env/meteor.json
+++ b/env/meteor.json
@@ -1,5 +1,6 @@
 {
   "versions": {
-    "1.2.0": "github:meteor-typings/meteor/1.2#64f0d62cb163049fd2c04c71ac1a8402b4ff6c9e"
+    "1.2.0": "github:meteor-typings/meteor/1.2#ab59b28167c5207feb93fbb6132ef8a6be98dbbb",
+    "1.3.0": "github:meteor-typings/meteor/1.3#ab59b28167c5207feb93fbb6132ef8a6be98dbbb"
   }
 }

--- a/lib/meteor.json
+++ b/lib/meteor.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.3.0": "github:meteor-typings/meteor/1.3#64f0d62cb163049fd2c04c71ac1a8402b4ff6c9e"
+  }
+}

--- a/lib/meteor.json
+++ b/lib/meteor.json
@@ -1,5 +1,0 @@
-{
-  "versions": {
-    "1.3.0": "github:meteor-typings/meteor/1.3#64f0d62cb163049fd2c04c71ac1a8402b4ff6c9e"
-  }
-}


### PR DESCRIPTION
https://github.com/meteor-typings/meteor

Move typings  to a new repo under meteor-typings organization.

Add typings for Meteor 1.2, which is ambient.

Typings for Meteor 1.3 now just defines new namespaces introduced in 1.3 which depends on globals from Meteor 1.2.



