### PR TITLE
Fix riot type exposure

### DIFF
--- a/npm/riot.json
+++ b/npm/riot.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "2.3.0": "github:effervescentia/typed-riot#0b70513564d3982fdd5cbd211ff30696b9ac8d97"
+    "2.3.0": "github:effervescentia/typed-riot#db2af9ea9d2ab08d3e56313e0c91e3a5f050d0cc"
   }
 }


### PR DESCRIPTION
**Typings URL:** https://github.com/effervescentia/typed-riot

**Change Summary:**

Fixed exposed types by moving accessors and interfaces up into the `riot` namespace.

