### PR TITLE
Added v4.0 to react-router-redux

### DIFF
--- a/npm/react-router-redux.json
+++ b/npm/react-router-redux.json
@@ -1,5 +1,6 @@
 {
   "versions": {
-    "3.0.0": "github:andrew-w-ross/typings-react-router-redux#7fece514b8d3de4a86f65104e0f7636a0f48046e"
+    "3.0.0": "github:andrew-w-ross/typings-react-router-redux#7fece514b8d3de4a86f65104e0f7636a0f48046e",
+    "4.0.0": "github:andrew-w-ross/typings-react-router-redux#caf792cb79efbf54ce328366809dc52821192a73"
   }
 }


### PR DESCRIPTION
Latest definition changes to [react-router-redux#caf792c](https://github.com/andrew-w-ross/typings-react-router-redux/commit/caf792cb79efbf54ce328366809dc52821192a73) are for v4.0.
Updating here so it can be used :)