### PR TITLE
Remove `moment` from registry

### DIFF
--- a/npm/moment.json
+++ b/npm/moment.json
@@ -1,5 +1,0 @@
-{
-  "versions": {
-    "2.10.5": "github:typed-typings/npm-moment#a4075cd50e63efbedd850f654594f293ab81a385"
-  }
-}


### PR DESCRIPTION
**Change Summary (for existing typings):**

The typings exist in the GitHub/NPM projects.
