### PR TITLE
Add typings for npm/gulp 3.9.1 and 4.0.0-alpha.2

### DIFF
--- a/npm/gulp.json
+++ b/npm/gulp.json
@@ -1,7 +1,7 @@
 {
   "versions": {
     "3.8.0": "github:typed-typings/npm-gulp#504da08753acdfe9dd2c415ab8fe36151e9645c1",
-    "3.9.1": "github:QuatroTypings/npm-gulp/3.9.1#03dcd625bd352aec00ece67e54acf40df13f3743",
-    "4.0.0-alpha.2": "github:QuatroTypings/npm-gulp/4.0.0-alpha.2#03dcd625bd352aec00ece67e54acf40df13f3743"
+    "3.9.1": "github:QuatroTypings/npm-gulp/3.9.1#a5c4542339854ac2adf6f1f009419a3274f6e71d",
+    "4.0.0-alpha.2": "github:QuatroTypings/npm-gulp/4.0.0-alpha.2#a5c4542339854ac2adf6f1f009419a3274f6e71d"
   }
 }

--- a/npm/gulp.json
+++ b/npm/gulp.json
@@ -1,5 +1,7 @@
 {
   "versions": {
-    "3.8.0": "github:typed-typings/npm-gulp#504da08753acdfe9dd2c415ab8fe36151e9645c1"
+    "3.8.0": "github:typed-typings/npm-gulp#504da08753acdfe9dd2c415ab8fe36151e9645c1",
+    "3.9.1": "github:QuatroTypings/npm-gulp/3.9.1#03dcd625bd352aec00ece67e54acf40df13f3743",
+    "4.0.0-alpha.2": "github:QuatroTypings/npm-gulp/4.0.0-alpha.2#03dcd625bd352aec00ece67e54acf40df13f3743"
   }
 }

--- a/npm/gulp.json
+++ b/npm/gulp.json
@@ -1,7 +1,7 @@
 {
   "versions": {
     "3.8.0": "github:typed-typings/npm-gulp#504da08753acdfe9dd2c415ab8fe36151e9645c1",
-    "3.9.1": "github:QuatroTypings/npm-gulp/3.9.1#a5c4542339854ac2adf6f1f009419a3274f6e71d",
-    "4.0.0-alpha.2": "github:QuatroTypings/npm-gulp/4.0.0-alpha.2#a5c4542339854ac2adf6f1f009419a3274f6e71d"
+    "3.9.1": "github:QuatroTypings/npm-gulp/3.9.1#fde183e53769c3dde81113f0932a21447ad1ee3a",
+    "4.0.0-alpha.2": "github:QuatroTypings/npm-gulp/4.0.0-alpha.2#fde183e53769c3dde81113f0932a21447ad1ee3a"
   }
 }


### PR DESCRIPTION
**Typings URL:** https://github.com/QuatroTypings/npm-gulp

**Questions (for new typings):**
* [X] Does the README explain the purpose of the typings and have a link to the JavaScript project?
* [X] Do the typings follow the source structure (e.g. `index.js` <-> `index.d.ts`)?
* [X] Are they external or global modules according the source (e.g. see README sources)?


Created new repository with:
* Travis tests.
* Typings tests.
* Different versions.