### PR TITLE
add common/noop.json

### DIFF
--- a/common/noop.json
+++ b/common/noop.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "0.1.0": "github:bigsan/common-noop#cb2c513367bf936da336eaf21a31ae4cd0d2ec1c"
+  }
+}


### PR DESCRIPTION
**Typings URL:** https://github.com/bigsan/common-noop

The noop module that prevents TypeScript from complaining about "Cannot find module".

See [typings/typings#110](https://github.com/typings/typings/issues/110#issuecomment-191064423) and [typings/registry#164](https://github.com/typings/registry/issues/164) for more detail.
