### PR TITLE
Add type definitions for node-static

### DIFF
--- a/npm/node-static.json
+++ b/npm/node-static.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "0.7.7": "github:effervescentia/typed-node-static#29ac1643342e18968ecf1a4ce0bca8c0f9055324"
+  }
+}


### PR DESCRIPTION
~~**Typings URL:** https://github.com/cloudhead/node-static~~
**Typings URL:** https://github.com/effervescentia/typed-node-static

**Questions (for new typings):**

* [x] Does the README explain the purpose of the typings and have a link to the JavaScript project?
* [x] Do the typings follow the source structure (e.g. `index.js` <-> `index.d.ts`)?
* [x] Are they external or global modules according the source (e.g. see README sources)?