### PR TITLE
update export format of xhr-mock

### DIFF
--- a/npm/xhr-mock.json
+++ b/npm/xhr-mock.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "1.6.0": "github:effervescentia/typed-xhr-mock#c3fea91aaeede6982f59dea2a6f6ad5291a5256b"
+    "1.6.0": "github:effervescentia/typed-xhr-mock#32d2bc6d4fada67d86e029b66e214450b2766196"
   }
 }


### PR DESCRIPTION
**Typings URL:** https://github.com/jameslnewell/xhr-mock

**Change Summary (for existing typings):**

Updated the export format to export functions directly and only use the alias style for `delete` method

