### PR TITLE
Updating lib/riotgames-api.json

### DIFF
--- a/lib/riotgames-api.json
+++ b/lib/riotgames-api.json
@@ -1,5 +1,6 @@
 {
   "versions": {
-    "1.0.0": "github:protectator/league-typedef#e2e171fde1587f3f4b92659641e2a45737ac98b0"
+    "1.0.0": "github:protectator/league-typedef#e2e171fde1587f3f4b92659641e2a45737ac98b0",
+    "1.1.0": "github:protectator/league-typedef#fdee9ce316c517b706deb60da51089cf5a37cf05"
   }
 }


### PR DESCRIPTION
**Typings URL:** https://github.com/Protectator/league-typedef

**Change Summary :**
Removing field `highestGrade` from the `championmastery` endpoint. For more details, official announcement from Riot Games here : [Link](https://developer.riotgames.com/discussion/announcements/show/qTAtcMAa)

Updating riotgames-api.json to version 1.1.0