### PR TITLE
add chai-spies to registry

### DIFF
--- a/npm/chai-spies.json
+++ b/npm/chai-spies.json
@@ -1,0 +1,5 @@
+{
+    "versions": {
+        "0.7.1": "github:whenther/typed-chai-spies#e8c648250e2fab1e1af54b0bb684ccd44d19cab8"
+    }
+}

--- a/npm/chai-spies.json
+++ b/npm/chai-spies.json
@@ -1,5 +1,5 @@
 {
     "versions": {
-        "0.7.1": "github:whenther/typed-chai-spies#e8c648250e2fab1e1af54b0bb684ccd44d19cab8"
+        "0.7.1": "github:whenther/typed-chai-spies#d5dbba153d3995984edf74cf1562b9eb8436841b"
     }
 }


### PR DESCRIPTION
**Typings URL:** https://github.com/whenther/typed-chai-spies

**Questions (for new typings):**

* [x] Does the README explain the purpose of the typings and have a link to the JavaScript project?
* [x] Do the typings follow the source structure (e.g. `index.js` <-> `index.d.ts`)?
* [x] Are they external or global modules according the source (e.g. see README sources)?

I took a crack at typing the chai-spies library, but ran into a couple problems:
- The library adds a `chai.spy()` function to the core `chai` object - but in trying to add that to the type definition, I'm running into the `Module augmentation cannot introduce new names into the top level scope.` error from [this issue](https://github.com/Microsoft/TypeScript/issues/6722). That's allowed on TS 1.9, so this works on `typescript@next`, but not on the stable channel. Is there a workaround that I don't know about?
- I used the yeoman generator, and I  think I followed the directions from it's [upgrade docs](https://github.com/typings/generator-typings/blob/master/UPGRADE.md) - but I must have something misconfigured, because I'm getting `cannot find module` errors in `test/test.ts`, even though when I import my `index.d.ts` into the project I'm using chai-spies in, everything is a-okay.
- Once I get the `cannot find module` issue sorted, I'd like to write some tests - but what's the difference between `test` and `source-test`?

Thanks!