### PR TITLE
Add typings for npm/gulp 3.9.1 and 4.0.0-alpha.2

### DIFF
--- a/npm/gulp.json
+++ b/npm/gulp.json
@@ -1,5 +1,7 @@
 {
   "versions": {
-    "3.8.0": "github:typed-typings/npm-gulp#504da08753acdfe9dd2c415ab8fe36151e9645c1"
+    "3.8.0": "github:typed-typings/npm-gulp/3.8.0#4ed9a4a3275559c73a396eff7e1fde3824951ebb",
+    "3.9.1": "github:typed-typings/npm-gulp/3.9.1#4ed9a4a3275559c73a396eff7e1fde3824951ebb",
+    "4.0.0-alpha.2": "github:typed-typings/npm-gulp/4.0.0-alpha.2#4ed9a4a3275559c73a396eff7e1fde3824951ebb"
   }
 }

--- a/npm/gulp.json
+++ b/npm/gulp.json
@@ -1,7 +1,7 @@
 {
   "versions": {
-    "3.8.0": "github:typed-typings/npm-gulp/3.8.0#4ed9a4a3275559c73a396eff7e1fde3824951ebb",
-    "3.9.1": "github:typed-typings/npm-gulp/3.9.1#4ed9a4a3275559c73a396eff7e1fde3824951ebb",
-    "4.0.0-alpha.2": "github:typed-typings/npm-gulp/4.0.0-alpha.2#4ed9a4a3275559c73a396eff7e1fde3824951ebb"
+    "3.8.0": "github:typed-typings/npm-gulp/3.8.0#66f3e68ce829908eb94912d8a0c9b4f97bc1ed61",
+    "3.9.1": "github:typed-typings/npm-gulp/3.9.1#66f3e68ce829908eb94912d8a0c9b4f97bc1ed61",
+    "4.0.0-alpha.2": "github:typed-typings/npm-gulp/4.0.0-alpha.2#66f3e68ce829908eb94912d8a0c9b4f97bc1ed61"
   }
 }


### PR DESCRIPTION
**Typings URL:** https://github.com/typed-typings/npm-gulp

Old pull request: #520 
