### PR TITLE
Type Definitions for Azure DocumentDB Node SDK

### DIFF
--- a/global/documentdb.json
+++ b/global/documentdb.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.8.0": "github:alexeldeib/typed-documentdb#efa8193d224bc397d6a100de7d1817f284077df6"
+  }
+}

--- a/npm/documentdb.json
+++ b/npm/documentdb.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "1.8.0": "github:alexeldeib/typed-documentdb#9408a45adb42f6ace36be486c6d0cca57219a552"
+  }
+}

--- a/npm/documentdb.json
+++ b/npm/documentdb.json
@@ -1,5 +1,0 @@
-{
-  "versions": {
-    "1.8.0": "github:alexeldeib/typed-documentdb#9408a45adb42f6ace36be486c6d0cca57219a552"
-  }
-}


### PR DESCRIPTION
**Typings URL:** https://github.com/alexeldeib/typed-documentdb

**Questions (for new typings):**

* [X] Does the README explain the purpose of the typings and have a link to the JavaScript project?
* [X] Do the typings follow the source structure (e.g. `index.js` <-> `index.d.ts`)?
* [X] Are they external or global modules according the source (e.g. see README sources)?

This is a major update to the Definitely Typed DocumentDB type definitions. It's not complete yet, but has type definitions for almost all of the 1.8.0 (current) version of the SDK.