### PR TITLE
update markdown-it commit hash

### DIFF
--- a/npm/markdown-it.json
+++ b/npm/markdown-it.json
@@ -1,6 +1,6 @@
 {
 	"versions": {
-		"4.0.0": "github:rapropos/typed-markdown-it#71e0f4babb2878267f54503ed89ad05609df71f3"
+		"4.0.0": "github:rapropos/typed-markdown-it#70184c9d393c09fb93e5cdac9ccf8df2a0f8d291"
 	}
 }
 


### PR DESCRIPTION
Reflecting merge of [PR to add plugin options](https://github.com/rapropos/typed-markdown-it/pull/2). Does not reflect breaking upstream API change.