### PR TITLE
Update bignumber.js typings

### DIFF
--- a/npm/bignumber.js.json
+++ b/npm/bignumber.js.json
@@ -1,5 +1,6 @@
 {
   "versions": {
-    "2.3.0": "github:felixfbecker/typed-bignumber.js#d93c7452a6d8a11c9f01b2c410a7b13cd6859927"
+    "2.3.0": "github:felixfbecker/typed-bignumber.js#d93c7452a6d8a11c9f01b2c410a7b13cd6859927",
+    "2.4.0": "github:felixfbecker/typed-bignumber.js#3ed5f6486e625fa897b76591afd935a2cf2b88b2"
   }
 }


### PR DESCRIPTION
**Typings URL:** https://github.com/felixfbecker/typed-bignumber.js

**Change Summary (for existing typings):**

Replaced `export = ` with named and default exports thanks to https://github.com/MikeMcl/bignumber.js/commit/34b79d1a0cbca866469cf75abdc62aecd40dd35d, export interfaces.

https://github.com/felixfbecker/typed-bignumber.js/commit/3ed5f6486e625fa897b76591afd935a2cf2b88b2

I hope I did the versioning thing right.
