### PR TITLE
Delete any-promise.json

### DIFF
--- a/npm/any-promise.json
+++ b/npm/any-promise.json
@@ -1,5 +1,0 @@
-{
-  "versions": {
-    "1.0.0": "github:types/npm-any-promise#17e3625f149665a0c20b818f3a772f56e6d746b7"
-  }
-}


### PR DESCRIPTION
`any-promise` now carries its own typings.

But this could break some builds.
Should we do it?