### PR TITLE
Add redux-persist reference

### DIFF
--- a/npm/redux-persist.json
+++ b/npm/redux-persist.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "3.2.2": "github:pellejacobs/typed-redux-persist#ff5ba445e7a055aa33a632c347d332ce8691115d"
+    "3.2.2": "github:pellejacobs/typed-redux-persist#146e3374a24160f1addf078ddaffbaa74e70b3cc"
   }
 }

--- a/npm/redux-persist.json
+++ b/npm/redux-persist.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "3.2.2": "github:pellejacobs/typed-redux-persist#82fc7d8cae06227c548a70e98f43ef77bab30cb6"
+    "3.2.2": "github:pellejacobs/typed-redux-persist#78616886cb5ebe7108b4e1b2b7d445abda35e287"
   }
 }

--- a/npm/redux-persist.json
+++ b/npm/redux-persist.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "3.2.2": "github:pellejacobs/typed-redux-persist#146e3374a24160f1addf078ddaffbaa74e70b3cc"
+    "3.2.2": "github:pellejacobs/typed-redux-persist#82fc7d8cae06227c548a70e98f43ef77bab30cb6"
   }
 }

--- a/npm/redux-persist.json
+++ b/npm/redux-persist.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "3.2.2": "github:pellejacobs/typed-redux-persist#ff5ba445e7a055aa33a632c347d332ce8691115d"
+  }
+}


### PR DESCRIPTION
**Typings URL:** https://github.com/pellejacobs/typed-redux-persist
**Questions (for new typings):**


* [x] Do the typings follow the source structure (e.g. `index.js` <-> `index.d.ts`)?

  Contains two files, index.d.ts and constants.d.ts

* [x] Are they external or global modules according the source (e.g. see README sources)?

  There is a dependency to the redux declaration file from the github repo.
* [x] Does the README explain the purpose of the typings and have a link to the JavaScript project?

