### PR TITLE
Add typings for gulp-sourcemaps v1.6.0 and v2.0.0-alpha

### DIFF
--- a/npm/gulp-sourcemaps.json
+++ b/npm/gulp-sourcemaps.json
@@ -1,0 +1,6 @@
+{
+  "versions": {
+    "1.6.0": "github:natevecc/typed-gulp-sourcemaps/1.6.0#4dea5751f6b943b637ba2c0c6967dc4010da6df5",
+    "2.0.0-alpha": "github:natevecc/typed-gulp-sourcemaps/2.0.0-alpha#4dea5751f6b943b637ba2c0c6967dc4010da6df5"
+  }
+}

--- a/npm/gulp-sourcemaps.json
+++ b/npm/gulp-sourcemaps.json
@@ -1,6 +1,6 @@
 {
   "versions": {
-    "1.6.0": "github:natevecc/typed-gulp-sourcemaps/1.6.0#4dea5751f6b943b637ba2c0c6967dc4010da6df5",
-    "2.0.0-alpha": "github:natevecc/typed-gulp-sourcemaps/2.0.0-alpha#4dea5751f6b943b637ba2c0c6967dc4010da6df5"
+    "1.6.0": "github:natevecc/typed-gulp-sourcemaps/1.6.0#cf9ea28864e083acc4adc46caddb407bfbb6836d",
+    "2.0.0-alpha": "github:natevecc/typed-gulp-sourcemaps/2.0.0-alpha#cf9ea28864e083acc4adc46caddb407bfbb6836d"
   }
 }


### PR DESCRIPTION
**Typings URL:** https://github.com/natevecc/typed-gulp-sourcemaps

**Questions (for new typings):**

* [ ] Does the README explain the purpose of the typings and have a link to the JavaScript project?
* [ ] Do the typings follow the source structure (e.g. `index.js` <-> `index.d.ts`)?
* [ ] Are they external or global modules according the source (e.g. see README sources)?

I followed the [gulp typings](https://github.com/typings/gulp-typings) structure to handle the multiple versions. If that's not right let me know and I can fix. Also if you want to move this under the typings organization I'm happy to assist with that as well.