### PR TITLE
riot typings fixes

### DIFF
--- a/npm/riot.json
+++ b/npm/riot.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "2.3.0": "github:effervescentia/typed-riot#ddff49dcf57dc64de0a7cbd471a8a6790ffa83cd"
+    "2.6.0": "github:effervescentia/typed-riot#76fbdced95089fa4c5a2e5c783ed83afcd004563"
   }
 }


### PR DESCRIPTION
**Typings URL:** https://github.com/effervescentia/typed-riot

**Change Summary (for existing typings):**

- add rest parameters for `riot.mixin()`
- Router is now composed by extending multiple other types rather than a union of those types


