### PR TITLE
Added typings for microsoftgraph/msgraph-typescript-typings

### DIFF
--- a/npm/msgraph-sdk-javascript.json
+++ b/npm/msgraph-sdk-javascript.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "0.1.0": "github:microsoftgraph/msgraph-typescript-typings#05e97952d573b2dd1f05578211f37fccbe138283"
+  }
+}

--- a/npm/msgraph-sdk-javascript.json
+++ b/npm/msgraph-sdk-javascript.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "0.1.0": "github:microsoftgraph/msgraph-typescript-typings#05e97952d573b2dd1f05578211f37fccbe138283"
+    "0.2.0": "github:microsoftgraph/msgraph-typescript-typings#a5bb450b61d0941f4e1fdbde11564243917e83ed"
   }
 }


### PR DESCRIPTION
**Typings URL:** https://github.com/microsoftgraph/msgraph-typescript-typings

**Questions (for new typings):**

* [x] Does the README explain the purpose of the typings and have a link to the JavaScript project?
* [x] Do the typings follow the source structure (e.g. `index.js` <-> `index.d.ts`)?

> I'm not sure this is applicable in our case since the typings are for the Microsoft Graph entities that are returned when hitting the API. This is not typings for a particular JavaScript library.

* [x] Are they external or global modules according the source (e.g. see README sources)?


**Change Summary (for existing typings):**

n/a
