### PR TITLE
Fixed filename for Microsoft Graph API typings - wrong GitHub repo was linked

### DIFF
--- a/common/microsoft-graph.json
+++ b/common/microsoft-graph.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "0.2.0": "github:microsoftgraph/msgraph-typescript-typings#d964a91520daf8bebc86730a9d9489217d6e8442"
+  }
+}

--- a/npm/msgraph-sdk-javascript.json
+++ b/npm/msgraph-sdk-javascript.json
@@ -1,5 +1,0 @@
-{
-  "versions": {
-    "0.2.0": "github:microsoftgraph/msgraph-typescript-typings#a5bb450b61d0941f4e1fdbde11564243917e83ed"
-  }
-}


### PR DESCRIPTION
**Typings URL:** https://github.com/microsoftgraph/msgraph-typescript-typings/blob/master/microsoft-graph.d.ts

**Change Summary (for existing typings):**
We have a [github repo for the Graph typings](https://github.com/microsoftgraph/msgraph-typescript-typings) (objects that are sent to/from the API) and this repo name should be the filename of the registry json file.  I incorrectly linked to our [separate SDK repo](https://github.com/microsoftgraph/msgraph-sdk-javascript) which has methods for interacting with the API.