### PR TITLE
Add typings for vandium

### DIFF
--- a/npm/vandium.json
+++ b/npm/vandium.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "3.2.0": "github:miltador/typed-vandium#88a4f22372aa6c9f4c7b65dc0a6bec360d633974"
+    "3.2.0": "github:miltador/typed-vandium#f3046eb3ca2237d174599853056b97020216faa9"
   }
 }

--- a/npm/vandium.json
+++ b/npm/vandium.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "3.2.0": "github:miltador/typed-vandium#92ba26d323043620ab3da150c216ff6fe2ff5763"
+    "3.2.0": "github:miltador/typed-vandium#88a4f22372aa6c9f4c7b65dc0a6bec360d633974"
   }
 }

--- a/npm/vandium.json
+++ b/npm/vandium.json
@@ -1,0 +1,5 @@
+{
+  "versions": {
+    "3.2.0": "github:miltador/typed-vandium#92ba26d323043620ab3da150c216ff6fe2ff5763"
+  }
+}


### PR DESCRIPTION
**Typings URL:** https://github.com/miltador/typed-vandium

**Questions (for new typings):**

* [X] Does the README explain the purpose of the typings and have a link to the JavaScript project?
* [X] Do the typings follow the source structure (e.g. `index.js` <-> `index.d.ts`)?
* [ ] Are they external or global modules according the source (e.g. see README sources)?

