### PR TITLE
Solve .vscode/settings.json invalid path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,7 +13,7 @@
         "/env/*.json",
         "/global/*.json"
       ],
-      "url": "/schema.json"
+      "url": "./schema.json"
     }
   ]
 }


### PR DESCRIPTION
I'm use last version of Visual Studio Code (1.6.1).

Current vscode settings for json schema is not valid:
* Show a warning that can find schema.json and don't validate json files.
![vscode-config-before](https://cloud.githubusercontent.com/assets/15308683/19838483/813e66e6-9ed0-11e6-817e-54c59428f86a.png)

After change:
* No warnings and validate files.
![vscode-config-after](https://cloud.githubusercontent.com/assets/15308683/19838484/81647480-9ed0-11e6-95f1-21e9a4574340.png)