### PR TITLE
Updated mongodb: Cursor.map returns cursor

### DIFF
--- a/npm/mongodb.json
+++ b/npm/mongodb.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "2.1.0": "github:Think7/typings-mongodb#f74e023451eb2fdc130b2fc660d1ff1938436054"
+    "2.1.0": "github:Think7/typings-mongodb#ce7030fab14d1166516a4fa79435f24ab85a02ad"
   }
 }


### PR DESCRIPTION
**Typings URL:** https://github.com/Think7/typings-mongodb

**Change Summary (for existing typings):**

Cursor.map returns cursor. The documentation was incorrect, it has now been fixed here https://github.com/mongodb/node-mongodb-native/pull/1428
<!-- Thanks for contributing! This information helps us and the community stay in sync. -->

