### PR TITLE
Update flux-standard-action

### DIFF
--- a/npm/flux-standard-action.json
+++ b/npm/flux-standard-action.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "0.5.0": "github:types/npm-flux-standard-action#922ff1efb12bc5db4bc0a6c0db49cc8f547d8afd"
+    "0.5.0": "github:types/npm-flux-standard-action#40b444515e68fd085afdf971c138c1ab6b395458"
   }
 }

--- a/npm/flux-standard-action.json
+++ b/npm/flux-standard-action.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "0.6.1": "github:types/npm-flux-standard-action#1db7005c857f2d9393e041fa4bb3c6422299e5bc"
+    "0.5.0": "github:types/npm-flux-standard-action#922ff1efb12bc5db4bc0a6c0db49cc8f547d8afd"
   }
 }


### PR DESCRIPTION
**Typings URL:** https://github.com/types/npm-flux-standard-action

**Questions (for new typings):**

* [x] Does the README explain the purpose of the typings and have a link to the JavaScript project?
* [x] Do the typings follow the source structure (e.g. `index.js` <-> `index.d.ts`)?
* [x] Are they external or global modules according the source (e.g. see README sources)?

**Change Summary (for existing typings):**
Consolidate with DT version.
Lower version requirement.

This will break someone who uses this typing as the interface is renamed from `FluxStandardAction` to `Action`, matching what's on `@types`. But it has to be done someway to avoid overall breakage.