### PR TITLE
Update riot typings to v3.0.1

### DIFF
--- a/npm/riot.json
+++ b/npm/riot.json
@@ -1,5 +1,6 @@
 {
   "versions": {
-    "2.6.0": "github:effervescentia/typed-riot#76fbdced95089fa4c5a2e5c783ed83afcd004563"
+    "2.6.0": "github:effervescentia/typed-riot#76fbdced95089fa4c5a2e5c783ed83afcd004563",
+    "3.0.1": "github:effervescentia/typed-riot#ac2567f22804b7d845202aa637ae1d5b8b4106ce"
   }
 }


### PR DESCRIPTION
**Typings URL:** https://github.com/effervescentia/typed-riot

**Change Summary (for existing typings):**

- add `isMounted`, `_riot_id` and `_parent` to `Tag.Instance` typings
- fix type of `tags` on `Tag.Instance`
- update for v3.0.1: 
  - add `refs` to `Tag.Instance`
  - remove `Router` and related typings
