### PR TITLE
add -RC0

### DIFF
--- a/npm/ramda.json
+++ b/npm/ramda.json
@@ -2,7 +2,7 @@
     "versions": {
         "0.19.1": "github:enriched/typed-ramda#413395cd890d7f3236ced0a9718da9a3869840ec",
         "0.21.0": "github:donnut/typescript-ramda#21164bfa6e9a9fde3111c0a96c691ff326d72fad",
-        "0.22.1": "github:types/npm-ramda#832a36096c4e6d857a141b27d9c5cfb5aeb6e95e",
-        "0.23.0": "github:types/npm-ramda#d73ca180396e58de8ede2e7a8e8faedb90ea611e"
+        "0.22.1-RC0": "github:types/npm-ramda#832a36096c4e6d857a141b27d9c5cfb5aeb6e95e",
+        "0.23.0-RC0": "github:types/npm-ramda#d73ca180396e58de8ede2e7a8e8faedb90ea611e"
     }
 }


### PR DESCRIPTION
**Typings URL:** https://github.com/types/npm-ramda/

**Change Summary (for existing typings):**

I wanna make sure we can still publish newer versions, and have the names remain to make sense, i.e. not have `-RCx` be a lower version than without it... although for our purposes I don't expect we should have a 'final' version for each Ramda version (which is what the main version number tie into to have them make some sense), as we might want to merge in fixes for older Ramda versions after publishing.

This to me begs the question whether this registry allows dynamically picking versions, e.g. if the user specificies `1.0`, then, lacking `1.0`, it could return `1.0-RC0`. If so, that'd be great, we'd have ways to allow users to either opt to lock into a version, or to grab a specific version.

I'd almost be inclined to conclude the current system encourages listing entries e.g. ` "d73ca180396e58de8ede2e7a8e8faedb90ea611e": "github:types/npm-ramda#d73ca180396e58de8ede2e7a8e8faedb90ea611e"` to allow keeping things granular. But it feels like it's beating the point of not using NPM straight away, so... eh, hopefully we can just end up going by that.
