### PR TITLE
Update npm/big-integer

### DIFF
--- a/npm/big-integer.json
+++ b/npm/big-integer.json
@@ -1,5 +1,5 @@
 {
   "versions": {
-    "1.6.15": "github:Demurgos/typed-big-integer#48689e49d3de3c500a549361fd132a6ad8af0954"
+    "1.6.15": "github:types/npm-big-integer#11f279bbe53cb313c093932b801a862c5ca9ee10"
   }
 }


### PR DESCRIPTION
The type definitions migrated to the `types` organization.

**Typings URL:** https://github.com/types/npm-big-integer

**Change Summary (for existing typings):**

The type definitions did not change. They just migrated from my personal namespace to the `types` organization (from `demurgos/typed-big-integer` to `types/npm-big-integer`). I opened some issues on this repo for the migration, but the definitions themselves should still be fine.

<!-- Thanks for contributing! This information helps us and the community stay in sync. -->
