### PR TITLE
Remove outdated Electron typings

### DIFF
--- a/env/electron.json
+++ b/env/electron.json
@@ -1,6 +1,0 @@
-{
-  "versions": {
-    "0.37.4": "github:types/env-electron#12d50b0040ef06e97b5a0bdc0021a0e10b252b3c",
-    "0.37.6": "github:types/env-electron#33b7814e99a685288e87a8756167d3230acaefeb"
-  }
-}


### PR DESCRIPTION
Electron is working on providing an official electron.d.ts (automatically generated from the API docs) electron/electron#4875. Please raise any concerns / ideas there.